### PR TITLE
Season statistics tackles

### DIFF
--- a/lib/season_stat.rb
+++ b/lib/season_stat.rb
@@ -118,7 +118,10 @@ module SeasonStatistics
     def most_tackles(season)
         ids = games_per_season(season)
         teams = team_tackles(ids)
-        teams
+        most_tackles = teams.values.max
+        team_with_most_tackles = teams.find {|team, tackles| tackles == most_tackles }
+        team_with_most_tackles
+        get_team_name(team_with_most_tackles[0])
     end
 
     def team_tackles(game_ids)
@@ -143,6 +146,4 @@ module SeasonStatistics
         team_ids[game_teams_object.team_id] += game_teams_object.tackles
         team_ids
     end
-
-
 end

--- a/lib/season_stat.rb
+++ b/lib/season_stat.rb
@@ -115,4 +115,34 @@ module SeasonStatistics
         get_team_name(team[0])
     end
 
+    def most_tackles(season)
+        ids = games_per_season(season)
+        teams = team_tackles(ids)
+        teams
+    end
+
+    def team_tackles(game_ids)
+        team_ids = {}
+        game_teams.each do |object|
+            if game_ids.include?(object.game_id)
+                team_id_hashes(object, team_ids)
+                update_tackles(object, team_ids)
+            end
+        end
+        team_ids
+    end
+
+    def team_id_hashes(game_teams_object, team_ids)
+        if team_ids[game_teams_object.team_id].nil?
+            team_ids[game_teams_object.team_id] = 0
+        end
+        team_ids
+    end
+
+    def update_tackles(game_teams_object, team_ids)
+        team_ids[game_teams_object.team_id] += game_teams_object.tackles
+        team_ids
+    end
+
+
 end

--- a/lib/season_stat.rb
+++ b/lib/season_stat.rb
@@ -124,6 +124,15 @@ module SeasonStatistics
         get_team_name(team_with_most_tackles[0])
     end
 
+    def fewest_tackles(season)
+        ids = games_per_season(season)
+        teams = team_tackles(ids)
+        fewest_tackles = teams.values.min
+        team_with_fewest_tackles = teams.find {|team, tackles| tackles == fewest_tackles }
+        team_with_fewest_tackles
+        get_team_name(team_with_fewest_tackles[0])
+    end
+
     def team_tackles(game_ids)
         team_ids = {}
         game_teams.each do |object|

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe StatTracker do
     end
 
     before(:each) do
-        game_path = './data/games.csv'
-        team_path = './data/teams.csv'
-        game_teams_path = './data/game_teams.csv'
+        game_path = './data/dummy_games.csv'
+        team_path = './data/dummy_teams.csv'
+        game_teams_path = './data/dummy_game_teams.csv'
 
         @locations = {
         games: game_path,
@@ -381,36 +381,46 @@ RSpec.describe StatTracker do
             it 'returns the team with the most tackles' do
                 season = '20122-13'
 
-                expect(@stat_tracker.most_tackles(season).to eq "The meanest team"
+                expect(@stat_tracker.most_tackles(season)).to eq "The meanest team"
             end
         end
-        # games per season
-        # team_tackles
-        # teams.max_by
-        # get team_name
+
+        describe 'helper#team tackles' do
+            it 'returns a hash with teams and tackles' do
+                game_ids = ['2012030221', '2012030232', '2012030222']
+                    hash = {
+                        "3" => 77,
+                        "6" => 87,
+                        "17" => 26,
+                        "16" => 36                    
+                    }
+                    
+                expect(@stat_tracker.team_tackles(game_ids)).to eq hash
+            end
         end
-
-
-        # games per season
-        # modify team_shot_goal so that it is just team_tackles
-        # modify team_id_hash to be an integer instead of an array
-        # modify update_shot goal - to be modify tackles - find key and incriment value by however many tackles
-        # 
-        # modify most/least accurate
-        # teams max_by
-        # teams min_by
-        # no need for ratio method
-
-
-        describe '#fewest_tackles' do
-        # games per season
-        # team_tackles
-        # teams.min_by
-        # get team_name
-        end
-
-       
     end
-
-
 end
+## games per season
+# team_tackles
+# teams.max_by
+# get team_name
+
+
+
+# games per season
+# modify team_shot_goal so that it is just team_tackles
+# modify team_id_hash to be an integer instead of an array
+# modify update_shot goal - to be modify tackles - find key and incriment value by however many tackles
+# 
+# modify most/least accurate
+# teams max_by
+# teams min_by
+# no need for ratio method
+
+
+# describe '#fewest_tackles' do
+# games per season
+# team_tackles
+# teams.min_by
+# get team_name
+# end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -378,10 +378,38 @@ RSpec.describe StatTracker do
         end
 
         describe '#most_tackles' do
+            it 'returns the team with the most tackles' do
+                season = '20122-13'
+
+                expect(@stat_tracker.most_tackles(season).to eq "The meanest team"
+            end
+        end
+        # games per season
+        # team_tackles
+        # teams.max_by
+        # get team_name
         end
 
+
+        # games per season
+        # modify team_shot_goal so that it is just team_tackles
+        # modify team_id_hash to be an integer instead of an array
+        # modify update_shot goal - to be modify tackles - find key and incriment value by however many tackles
+        # 
+        # modify most/least accurate
+        # teams max_by
+        # teams min_by
+        # no need for ratio method
+
+
         describe '#fewest_tackles' do
+        # games per season
+        # team_tackles
+        # teams.min_by
+        # get team_name
         end
+
+       
     end
 
 

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -398,6 +398,18 @@ RSpec.describe StatTracker do
                 expect(@stat_tracker.team_tackles(game_ids)).to eq hash
             end
         end
+
+        describe 'helper#team id hashes' do
+            it 'returns a hash' do
+                game_1 = @stat_tracker.game_teams.find {|game| game.game_id == '2012030221'}
+                hash = {"3" => 0}
+                teams = {}
+
+                expect(@stat_tracker.team_id_hashes(game_1, teams)).to eq hash
+            end
+        end
+
+
     end
 end
 ## games per season

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -424,7 +424,7 @@ RSpec.describe StatTracker do
             it 'returns the team with the most tackles' do
                 season = '20122013'
 
-                expect(@stat_tracker.fewest_tackles(season)).to eq "FC Jimbo"
+                expect(@stat_tracker.fewest_tackles(season)).to eq "Atlanta United"
             end
         end
 

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -419,6 +419,15 @@ RSpec.describe StatTracker do
                 expect(@stat_tracker.most_tackles(season)).to eq "FC Cincinnati"
             end
         end
+
+        describe '#fewest_tackles' do
+            it 'returns the team with the most tackles' do
+                season = '20122013'
+
+                expect(@stat_tracker.fewest_tackles(season)).to eq "FC Jimbo"
+            end
+        end
+
     end
 end
 ## games per season

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -281,8 +281,6 @@ RSpec.describe StatTracker do
         end
 
         describe '#most_accurate_team' do
-        # max will get the team_id
-        # team_id to team name
             it 'gets game_ids per season' do
                 expect(@stat_tracker.games_per_season("20122013")).to be_a Array
             end
@@ -377,14 +375,6 @@ RSpec.describe StatTracker do
             end
         end
 
-        describe '#most_tackles' do
-            it 'returns the team with the most tackles' do
-                season = '20122-13'
-
-                expect(@stat_tracker.most_tackles(season)).to eq "The meanest team"
-            end
-        end
-
         describe 'helper#team tackles' do
             it 'returns a hash with teams and tackles' do
                 game_ids = ['2012030221', '2012030232', '2012030222']
@@ -419,6 +409,14 @@ RSpec.describe StatTracker do
                 expect(teams["3"]).to eq 0
 
                 expect(@stat_tracker.update_tackles(game_1, teams)).to eq({"3" => 44})
+            end
+        end
+
+        describe '#most_tackles' do
+            it 'returns the team with the most tackles' do
+                season = '20122013'
+
+                expect(@stat_tracker.most_tackles(season)).to eq "FC Cincinnati"
             end
         end
     end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe StatTracker do
     end
 
     before(:each) do
-        game_path = './data/dummy_games.csv'
-        team_path = './data/dummy_teams.csv'
-        game_teams_path = './data/dummy_game_teams.csv'
+        game_path = './data/games.csv'
+        team_path = './data/teams.csv'
+        game_teams_path = './data/game_teams.csv'
 
         @locations = {
         games: game_path,
@@ -400,6 +400,7 @@ RSpec.describe StatTracker do
         end
 
         describe 'helper#team id hashes' do
+        #rename later
             it 'returns a hash' do
                 game_1 = @stat_tracker.game_teams.find {|game| game.game_id == '2012030221'}
                 hash = {"3" => 0}
@@ -409,7 +410,17 @@ RSpec.describe StatTracker do
             end
         end
 
+        describe 'helper#update tackles' do
+            it 'updates team_id hashes with tackles' do
+                game_1 = @stat_tracker.game_teams.find {|game| game.game_id == '2012030221'}
+                hash = {"3" => 0}
+                teams = {}
+                @stat_tracker.team_id_hashes(game_1, teams)
+                expect(teams["3"]).to eq 0
 
+                expect(@stat_tracker.update_tackles(game_1, teams)).to eq({"3" => 44})
+            end
+        end
     end
 end
 ## games per season


### PR DESCRIPTION
method: team tackles = returns hash with team ids as the key and the number of tackles as the value

method: team_id_hashes = returns a hash with the team id as the key and the number of tackles as the value

method: update tackles = increases a team's running tally of tackles through the season per game

method: most_tackles: uses helper methods to return the team with the most tackles

method: fewest_tackles = uses helper methods to return the team name with the fewest tackles